### PR TITLE
Theme & Plugin actions

### DIFF
--- a/wp-cli-remote-command.php
+++ b/wp-cli-remote-command.php
@@ -61,6 +61,18 @@ class WP_CLI_Remote_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Install a given theme on a given site.
+	 *
+	 * @subcommand theme-install
+	 * @synopsis <site-id> <theme-name>
+	 */
+	public function theme_install( $args, $assoc_args ) {
+
+		list( $site_id, $theme_name ) = $args;
+		$this->perform_plugin_or_theme_action_for_site( 'theme', 'install', $theme_name, $site_id );
+	}
+
+	/**
 	 * Delete a given theme on a given site.
 	 *
 	 * @subcommand theme-delete

--- a/wp-cli-remote-command.php
+++ b/wp-cli-remote-command.php
@@ -42,6 +42,66 @@ class WP_CLI_Remote_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Install a given plugin on a given site.
+	 *
+	 * @subcommand plugin-install
+	 * @synopsis <site-id> <plugin-name> [--version=<version>]
+	 */
+	public function plugin_install( $args, $assoc_args ) {
+
+		list( $site_id, $plugin_name ) = $args;
+		$this->perform_plugin_or_theme_action_for_site( 'plugin', 'install', $plugin_name, $site_id, $assoc_args );
+	}
+
+	/**
+	 * Activate a given plugin on a given site.
+	 *
+	 * @subcommand plugin-activate
+	 * @synopsis <site-id> <plugin-name>
+	 */
+	public function plugin_activate( $args ) {
+
+		list( $site_id, $plugin_name ) = $args;
+		$this->perform_plugin_or_theme_action_for_site( 'plugin', 'activate', $plugin_name, $site_id );
+	}
+
+	/**
+	 * Deactivate a given plugin on a given site.
+	 *
+	 * @subcommand plugin-deactivate
+	 * @synopsis <site-id> <plugin-name>
+	 */
+	public function plugin_deactivate( $args ) {
+
+		list( $site_id, $plugin_name ) = $args;
+		$this->perform_plugin_or_theme_action_for_site( 'plugin', 'deactivate', $plugin_name, $site_id );
+	}
+
+	/**
+	 * Update a given plugin on a given site.
+	 *
+	 * @subcommand plugin-update
+	 * @synopsis <site-id> <plugin-name>
+	 */
+	public function plugin_update( $args ) {
+
+		list( $site_id, $plugin_name ) = $args;
+		$this->perform_plugin_or_theme_action_for_site( 'plugin', 'update', $plugin_name, $site_id );
+	}
+
+	/**
+	 * Uninstall a given plugin on a given site.
+	 *
+	 * @subcommand plugin-uninstall
+	 * @synopsis <site-id> <plugin-name>
+	 */
+	public function plugin_uninstall( $args, $assoc_args ) {
+
+		list( $site_id, $plugin_name ) = $args;
+		$this->perform_plugin_or_theme_action_for_site( 'plugin', 'uninstall', $plugin_name, $site_id );
+	}
+
+	/**
 	 * List all of the themes installed on a given site.
 	 * 
 	 * @subcommand theme-list

--- a/wp-cli-remote-command.php
+++ b/wp-cli-remote-command.php
@@ -64,12 +64,12 @@ class WP_CLI_Remote_Command extends WP_CLI_Command {
 	 * Install a given theme on a given site.
 	 *
 	 * @subcommand theme-install
-	 * @synopsis <site-id> <theme-name>
+	 * @synopsis <site-id> <theme-name> [--version=<version>]
 	 */
 	public function theme_install( $args, $assoc_args ) {
 
 		list( $site_id, $theme_name ) = $args;
-		$this->perform_plugin_or_theme_action_for_site( 'theme', 'install', $theme_name, $site_id );
+		$this->perform_plugin_or_theme_action_for_site( 'theme', 'install', $theme_name, $site_id, $assoc_args );
 	}
 
 	/**
@@ -261,7 +261,7 @@ class WP_CLI_Remote_Command extends WP_CLI_Command {
 	 * 
 	 * @param string        $action     An action like 'install'
 	 */
-	private function perform_plugin_or_theme_action_for_site( $object, $action, $name, $site_id ) {
+	private function perform_plugin_or_theme_action_for_site( $object, $action, $name, $site_id, $assoc_args = array() ) {
 
 		$this->set_account();
 
@@ -276,6 +276,7 @@ class WP_CLI_Remote_Command extends WP_CLI_Command {
 		$args = array(
 			'endpoint'     => '/' . implode( '/', $endpoint ) . '/',
 			'method'       => 'POST',
+			'body'         => $assoc_args,
 			);
 		$response = $this->api_request( $args );
 		if ( is_wp_error( $response ) )

--- a/wp-cli-remote-command.php
+++ b/wp-cli-remote-command.php
@@ -306,12 +306,6 @@ class WP_CLI_Remote_Command extends WP_CLI_Command {
 		if ( is_wp_error( $response ) )
 			WP_CLI::error( $response->get_error_message() );
 
-		$args = array(
-			'endpoint'     => '/sites/' . $site_id . '/refresh_data',
-			'method'       => 'POST',
-			);
-		$response = $this->api_request( $args );
-
 		$action_past_tense = rtrim( $action, 'e' ) . 'ed';
 		WP_CLI::success( sprintf( "%s was %s.", ucwords( $object ), $action_past_tense ) );
 	}

--- a/wp-cli-remote-command.php
+++ b/wp-cli-remote-command.php
@@ -61,6 +61,18 @@ class WP_CLI_Remote_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Delete a given theme on a given site.
+	 *
+	 * @subcommand theme-delete
+	 * @synopsis <site-id> <theme-name>
+	 */
+	public function theme_delete( $args, $assoc_args ) {
+
+		list( $site_id, $theme_name ) = $args;
+		$this->perform_plugin_or_theme_action_for_site( 'theme', 'delete', $theme_name, $site_id );
+	}
+
+	/**
 	 * List all of the sites in your WP Remote account.
 	 * 
 	 * @subcommand site-list
@@ -230,6 +242,34 @@ class WP_CLI_Remote_Command extends WP_CLI_Command {
 		}
 
 		WP_CLI\Utils\format_items( $assoc_args['format'], $items, $assoc_args['fields'] );
+	}
+
+	/**
+	 * Perform a plugin or theme action for a site.
+	 * 
+	 * @param string        $action     An action like 'install'
+	 */
+	private function perform_plugin_or_theme_action_for_site( $object, $action, $name, $site_id ) {
+
+		$this->set_account();
+
+		$endpoint = array(
+				'sites',
+				$site_id,
+				$object,
+				$name,
+				$action
+			);
+
+		$args = array(
+			'endpoint'     => '/' . implode( '/', $endpoint ) . '/',
+			'method'       => 'POST',
+			);
+		$response = $this->api_request( $args );
+		if ( is_wp_error( $response ) )
+			WP_CLI::error( $response->get_error_message() );
+
+
 	}
 
 	/**

--- a/wp-cli-remote-command.php
+++ b/wp-cli-remote-command.php
@@ -306,6 +306,12 @@ class WP_CLI_Remote_Command extends WP_CLI_Command {
 		if ( is_wp_error( $response ) )
 			WP_CLI::error( $response->get_error_message() );
 
+		$args = array(
+			'endpoint'     => '/sites/' . $site_id . '/refresh_data',
+			'method'       => 'POST',
+			);
+		$response = $this->api_request( $args );
+
 		$action_past_tense = rtrim( $action, 'e' ) . 'ed';
 		WP_CLI::success( sprintf( "%s was %s.", ucwords( $object ), $action_past_tense ) );
 	}

--- a/wp-cli-remote-command.php
+++ b/wp-cli-remote-command.php
@@ -282,7 +282,8 @@ class WP_CLI_Remote_Command extends WP_CLI_Command {
 		if ( is_wp_error( $response ) )
 			WP_CLI::error( $response->get_error_message() );
 
-
+		$action_past_tense = rtrim( $action, 'e' ) . 'ed';
+		WP_CLI::success( sprintf( "%s was %s.", ucwords( $object ), $action_past_tense ) );
 	}
 
 	/**

--- a/wp-cli-remote-command.php
+++ b/wp-cli-remote-command.php
@@ -85,6 +85,18 @@ class WP_CLI_Remote_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Update a given theme on a given site.
+	 *
+	 * @subcommand theme-update
+	 * @synopsis <site-id> <theme-name>
+	 */
+	public function theme_update( $args ) {
+
+		list( $site_id, $theme_name ) = $args;
+		$this->perform_plugin_or_theme_action_for_site( 'theme', 'update', $theme_name, $site_id );
+	}
+
+	/**
 	 * Delete a given theme on a given site.
 	 *
 	 * @subcommand theme-delete

--- a/wp-cli-remote-command.php
+++ b/wp-cli-remote-command.php
@@ -73,6 +73,18 @@ class WP_CLI_Remote_Command extends WP_CLI_Command {
 	}
 
 	/**
+	 * Activate a given theme on a given site.
+	 *
+	 * @subcommand theme-activate
+	 * @synopsis <site-id> <theme-name>
+	 */
+	public function theme_activate( $args ) {
+
+		list( $site_id, $theme_name ) = $args;
+		$this->perform_plugin_or_theme_action_for_site( 'theme', 'activate', $theme_name, $site_id );
+	}
+
+	/**
 	 * Delete a given theme on a given site.
 	 *
 	 * @subcommand theme-delete


### PR DESCRIPTION
It would be nice to be able to install, activate, deactivate and delete themes & plugins using WP Remote.
- [x] wp remote plugin-install
- [x] wp remote plugin-activate
- [x] wp remote plugin-deactivate
- [x] wp remote plugin-uninstall
- [x] wp remote theme-install
- [x] wp remote theme-activate
- [x] wp remote theme-delete
