### PR TITLE
Create a Composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "humanmade/wp-cli-remote-command",
+    "description": "Manage your WordPress sites using WP Remote and WP-CLI.",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Humanmade",
+            "email": "hello@hmn.md"
+        }
+    ],
+    "minimum-stability": "dev",
+    "require": {
+
+    }
+}


### PR DESCRIPTION
Required so that the repo can be published in the WP-CLI package index.
