### PR TITLE
Consider consolidating `wp remote-backup initiate-download` and `wp remote-backup download`

### DIFF
--- a/commands/class-wp-remote-backup-command.php
+++ b/commands/class-wp-remote-backup-command.php
@@ -112,6 +112,34 @@ class WP_Remote_Backup_Command extends WP_Remote_Command {
 	}
 
 	/**
+	 * Download a given backup for a given site
+	 * 
+	 * @subcommand download
+	 * @synopsis <backup-id> --site-id=<site-id>
+	 */
+	public function download( $args, $assoc_args ) {
+
+		$site_id = $assoc_args['site-id'];
+
+		list( $backup_id ) = $args;
+
+		$this->set_account();
+
+		$args = array(
+			'endpoint'     => '/sites/' . (int)$site_id . '/backup/' . (int)$backup_id,
+			'method'       => 'GET',
+			);
+		$backup = $this->api_request( $args );
+
+		if ( is_wp_error( $backup ) )
+			WP_CLI::error( $backup->get_error_message() );
+
+		WP_CLI::launch( sprintf( "wget '%s'", $backup->url ) );
+
+		WP_CLI::success( "Backup downloaded." );
+	}
+
+	/**
 	 * Delete a given backup for a given site
 	 * 
 	 * @synopsis <backup-id> --site-id=<site-id>

--- a/commands/class-wp-remote-backup-command.php
+++ b/commands/class-wp-remote-backup-command.php
@@ -137,58 +137,6 @@ class WP_Remote_Backup_Command extends WP_Remote_Command {
 	}
 
 	/**
-	 * Initiate a download of the a site, use "download" once complete.
-	 * 
-	 * @subcommand initiate-download
-	 * @synopsis --site-id=<site-id>
-	 */
-	public function initiate_download( $args, $assoc_args ) {
-
-		$site_id = $assoc_args['site-id'];
-		$this->set_account();
-
-		$args = array(
-			'endpoint'     => '/sites/' . $site_id . '/backup/initiate-download',
-			'method'       => 'POST',
-			);
-
-		$response = $this->api_request( $args );
-
-		if ( is_wp_error( $response ) )
-			WP_CLI::error( $response->get_error_message() );
-
-		WP_CLI::success( 'Initiated download of site, run "download" to get the status' );
-
-	}
-
-	/**
-	 * Access the status of an on-demand backup
-	 * 
-	 * @synopsis --site-id=<site-id>
-	 */
-	public function download( $args, $assoc_args ) {
-
-		$site_id = $assoc_args['site-id'];
-		$this->set_account();
-
-		$args = array(
-			'endpoint'     => '/sites/' . $site_id . '/backup/download',
-			'method'       => 'GET',
-			);
-
-		$response = $this->api_request( $args );
-
-		if ( is_wp_error( $response ) )
-			WP_CLI::error( $response->get_error_message() );
-
-		if ( $response->status === 'backup-complete' )
-			WP_Cli::success( $response->url );
-
-		else
-			WP_Cli::error( 'Backup status: ' . $response->status );
-	}
-
-	/**
 	 * List the exclude rules for backups
 	 * 
 	 * @subcommand list-excludes

--- a/commands/class-wp-remote-site-command.php
+++ b/commands/class-wp-remote-site-command.php
@@ -135,7 +135,7 @@ class WP_Remote_Site_Command extends WP_Remote_Command {
 		if ( is_wp_error( $response ) )
 			WP_CLI::error( $response->get_error_message() );
 
-		WP_CLI::launch( sprintf( "wget %s", $response->url ) );
+		WP_CLI::launch( sprintf( "wget '%s'", $response->url ) );
 
 		WP_CLI::success( "Site downloaded." );
 	}

--- a/commands/class-wp-remote-site-command.php
+++ b/commands/class-wp-remote-site-command.php
@@ -91,7 +91,54 @@ class WP_Remote_Site_Command extends WP_Remote_Command {
 			WP_CLI::error( $response->get_error_message() );
 
 		WP_CLI::success( "Site refreshed." );
-	}	
+	}
+
+	/**
+	 * Download a remote site.
+	 * 
+	 * @subcommand download
+	 * @synopsis --site-id=<site-id>
+	 */
+	public function download( $args, $assoc_args ) {
+
+		$site_id = $assoc_args['site-id'];
+		$this->set_account();
+
+		$args = array(
+			'endpoint'     => '/sites/' . $site_id . '/download',
+			'method'       => 'POST',
+			);
+
+		$response = $this->api_request( $args );
+
+		if ( is_wp_error( $response ) )
+			WP_CLI::error( $response->get_error_message() );
+
+		WP_CLI::line( "Initiated site archive." );
+
+		do {
+
+			if ( ! empty( $response->status ) ) {
+				WP_Cli::line( 'Backup status: ' . $response->status );
+				sleep( 15 );
+			}
+
+			$args = array(
+			'endpoint'     => '/sites/' . $site_id . '/download',
+			'method'       => 'GET',
+			);
+
+			$response = $this->api_request( $args );
+
+		} while ( ! is_wp_error( $response ) && $response->status != 'backup-complete' );
+
+		if ( is_wp_error( $response ) )
+			WP_CLI::error( $response->get_error_message() );
+
+		WP_CLI::launch( sprintf( "wget %s", $response->url ) );
+
+		WP_CLI::success( "Site downloaded." );
+	}
 
 }
 


### PR DESCRIPTION
The user's intention likely is just to have the file for local access.

Alternatively, these two could become `wp remote-site download` (with a loop mechanism), and `wp remote-backup download` would download the file for a specific backup ID.
