### PR TITLE
Support for getting history across multiple remote sites in one go

### DIFF
--- a/commands/class-wp-remote-site-command.php
+++ b/commands/class-wp-remote-site-command.php
@@ -40,7 +40,6 @@ class WP_Remote_Site_Command extends WP_Remote_Command {
 			'endpoint'     => '/site/history/',
 			'method'       => 'GET',
 			'body'         => array(
-				'site_ids' => ( ! empty( $assoc_args['site-id'] ) ) ? $assoc_args['site-id'] : '',
 				'per_page' => (int)$assoc_args['per-page'],
 				'page'     => (int)$assoc_args['page'],
 				'type'     => $assoc_args['type'],
@@ -49,6 +48,10 @@ class WP_Remote_Site_Command extends WP_Remote_Command {
 				'end_timestamp'   => ( $assoc_args['end-date'] ) ? strtotime( $assoc_args['end-date'] ) : '',
 				),
 			);
+
+		if ( ! empty( $assoc_args['site-id'] ) )
+			$args['body']['site_ids'] = $assoc_args['site-id'];	
+
 		$response = $this->api_request( $args );
 		if ( is_wp_error( $response ) )
 			WP_CLI::error( $response->get_error_message() );

--- a/commands/class-wp-remote-site-command.php
+++ b/commands/class-wp-remote-site-command.php
@@ -50,7 +50,7 @@ class WP_Remote_Site_Command extends WP_Remote_Command {
 			);
 
 		if ( ! empty( $assoc_args['site-id'] ) )
-			$args['body']['site_ids'] = $assoc_args['site-id'];	
+			$args['body']['site_id'] = $assoc_args['site-id'];	
 
 		$response = $this->api_request( $args );
 		if ( is_wp_error( $response ) )

--- a/commands/class-wp-remote-site-command.php
+++ b/commands/class-wp-remote-site-command.php
@@ -15,7 +15,7 @@ class WP_Remote_Site_Command extends WP_Remote_Command {
 	 * View the history for a given site.
 	 *
 	 * @subcommand list-history
-	 * @synopsis --site-id=<site-id> [--type=<type>] [--action=<action>] [--start-date=<start-date>] [--end-date=<end-date>] [--per-page=<per-page>] [--page=<page>] [--format=<format>]
+	 * @synopsis [--site-id=<site-id>] [--type=<type>] [--action=<action>] [--start-date=<start-date>] [--end-date=<end-date>] [--per-page=<per-page>] [--page=<page>] [--format=<format>]
 	 */
 	public function list_history( $args, $assoc_args ) {
 
@@ -37,9 +37,10 @@ class WP_Remote_Site_Command extends WP_Remote_Command {
 		$this->set_account();
 
 		$args = array(
-			'endpoint'     => '/site/' . $site_id . '/history/',
+			'endpoint'     => '/site/history/',
 			'method'       => 'GET',
 			'body'         => array(
+				'site_ids' => ( ! empty( $assoc_args['site-id'] ) ) ? $assoc_args['site-id'] : '',
 				'per_page' => (int)$assoc_args['per-page'],
 				'page'     => (int)$assoc_args['page'],
 				'type'     => $assoc_args['type'],

--- a/commands/class-wp-remote-site-command.php
+++ b/commands/class-wp-remote-site-command.php
@@ -19,8 +19,8 @@ class WP_Remote_Site_Command extends WP_Remote_Command {
 	 */
 	public function list_history( $args, $assoc_args ) {
 
-		$site_id = $assoc_args['site-id'];
-		unset( $assoc_args['site-id'] );
+		if ( empty( $assoc_args['site-id'] ) || ( count( explode( ',', $assoc_args['site-id'] ) ) != 1 ) )
+			array_unshift( $this->history_fields, 'site_name' );
 
 		$defaults = array(
 				'per-page'    => 10,


### PR DESCRIPTION
One substantial change here is that `--site-id` is no longer a required argument for `wp remote-site list-history`
